### PR TITLE
Code fix for CreateRequests.cs

### DIFF
--- a/src/SdkSnippets/Snippets/CreateRequests.cs
+++ b/src/SdkSnippets/Snippets/CreateRequests.cs
@@ -65,7 +65,7 @@ public static class CreateRequests
             .GetAsync(requestConfiguration =>
             {
                 requestConfiguration.QueryParameters.Select =
-                    ["displayName", "jobTitle"];
+                    new string[] {"displayName", "jobTitle"};
             });
         // </SelectRequestSnippet>
 


### PR DESCRIPTION
Fixed MakeSelectRequest() that published:

   requestConfiguration.QueryParameters.Select =
                    ["displayName", "jobTitle"];

which is incorrect by correcting the string[] instantiation to be:

   requestConfiguration.QueryParameters.Select =
                    new string[] {"displayName", "jobTitle"};